### PR TITLE
Make fileutil build on OSX, removing fadvise support.

### DIFF
--- a/fileutil.go
+++ b/fileutil.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"runtime"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -169,16 +168,3 @@ const (
 	POSIX_FADV_DONTNEED                        // Don't need these pages.  
 	POSIX_FADV_NOREUSE                         // Data will be accessed once.  
 )
-
-// Fadvise predeclares an access pattern for file data.
-// See also 'man 2 posix_fadvise'.
-func Fadvise(f *os.File, off, len int64, advice FadviseAdvice) (err error) {
-	_, _, errno := syscall.Syscall6(
-		syscall.SYS_FADVISE64,
-		uintptr(f.Fd()),
-		uintptr(off),
-		uintptr(len),
-		uintptr(advice),
-		0, 0)
-	return os.NewSyscallError("SYS_FADVISE64", errno)
-}

--- a/fileutil_darwin.go
+++ b/fileutil_darwin.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2011 CZ.NIC z.s.p.o. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// blame: jnml, labs.nic.cz
+
+package fileutil
+
+import (
+	"fmt"
+	"os"
+)
+
+// Fadvise predeclares an access pattern for file data.
+// See also 'man 2 posix_fadvise'. Not available in OSX.
+func Fadvise(f *os.File, off, len int64, advice FadviseAdvice) (err error) {
+	return os.NewSyscallError("SYS_FADVISE64", fmt.Errorf("not implemented"))
+}

--- a/fileutil_linux.go
+++ b/fileutil_linux.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2011 CZ.NIC z.s.p.o. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// blame: jnml, labs.nic.cz
+package fileutil
+
+import (
+	"os"
+	"syscall"
+)
+// Fadvise predeclares an access pattern for file data.
+// See also 'man 2 posix_fadvise'.
+func Fadvise(f *os.File, off, len int64, advice FadviseAdvice) (err error) {
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_FADVISE64,
+		uintptr(f.Fd()),
+		uintptr(off),
+		uintptr(len),
+		uintptr(advice),
+		0, 0)
+	return os.NewSyscallError("SYS_FADVISE64", errno)
+}


### PR DESCRIPTION
Builds and tests PASS on OSX and linux i686.

Does not yet compile on amd, but this wasn't working before anyway.

go/src/pkg/github.com/nictuku/fileutil/fileutil_linux.go:16: undefined: syscall.
SYS_FADVISE64                
