### PR TITLE
Fails to build on arm/darwin due to duplicate symbols.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,5 +10,6 @@
 
 CZ.NIC z.s.p.o. <kontakt@nic.cz>
 Jan Mercl <0xjnml@gmail.com>
+Linelane GmbH <info@linelane.com>
 Aaron Bieber <deftly@gmail.com>
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,6 +6,7 @@
 #
 # Please keep the list sorted.
 
+Andris Valums <info@linelane.com>
 Bill Thiede <xinu.tv>
 Gary Burd <gary@beagledreams.com>
 Jan Mercl <0xjnml@gmail.com>

--- a/fileutil_darwin.go
+++ b/fileutil_darwin.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !arm
+
 package fileutil
 
 import (


### PR DESCRIPTION
Exclude fileutil_darwin.go when building for ARM. Issue #14.